### PR TITLE
Ability to 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ moodle-local_boostnavigation
 
 Moodle plugin which tries to overcome some fixed appearance behaviours of Boost's nav drawer in a clean way
 
+MY FORK
+-------
+
+Conditionals - the ability to target logged-on or non-logged-on users, guests, admins outside admin nodes, or exact users by the id.
+
 
 Requirements
 ------------

--- a/lang/en/local_boostnavigation.php
+++ b/lang/en/local_boostnavigation.php
@@ -194,4 +194,4 @@ $string['settingspage_customcoursenodes'] = 'Custom course nodes';
 $string['settingspage_customrootnodes'] = 'Custom root nodes';
 $string['settingspage_mycoursesrootnode'] = 'My courses root node';
 $string['settingspage_rootnodes'] = 'Root nodes';
-$string['setting_conditionals'] = '<b>Conditionally showing items.</b><br />You can prefix a link title with a special 3-character code to affect the visibility of the custom node.<br />Use <code>!a!</code> to target only site admins.<br />Use <code>!u!</code> to specify logged on users only.<br />Use <code>!U!</code> to specify logged off users only.<br />Use <code>!g!</code> to target only guest users.<br />';
+$string['setting_conditionals'] = '<b>Conditionally showing items.</b><br />You can prefix a link title with a special 3-character code to affect the visibility of the custom node.<br />Use <code>!a!</code> to target only site admins.<br />Use <code>!u!</code> to specify logged on users only.<br />Use <code>!U!</code> to specify logged off users only.<br />Use <code>!g!</code> to target only guest users.<br />Use <code>!1234!</code> to target user with ID 1234.';

--- a/lang/en/local_boostnavigation.php
+++ b/lang/en/local_boostnavigation.php
@@ -194,3 +194,4 @@ $string['settingspage_customcoursenodes'] = 'Custom course nodes';
 $string['settingspage_customrootnodes'] = 'Custom root nodes';
 $string['settingspage_mycoursesrootnode'] = 'My courses root node';
 $string['settingspage_rootnodes'] = 'Root nodes';
+$string['setting_conditionals'] = '<b>Conditionally showing items.</b><br />You can prefix a link title with a special 3-character code to affect the visibility of the custom node.<br />Use <code>!a!</code> to target only site admins.<br />Use <code>!u!</code> to specify logged on users only.<br />Use <code>!U!</code> to specify logged off users only.<br />Use <code>!g!</code> to target only guest users.<br />';

--- a/locallib.php
+++ b/locallib.php
@@ -24,6 +24,12 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+// make conditions easier to read; assuming length of 3
+define('CONDITION_IS_LOGGED_IN', '!u!');
+define('CONTITION_NOT_LOGGED_IN', '!U!');
+define('CONDITION_IS_GUEST','!g!');
+define('CONTITION_IS_ADMIN', '!a!');
+
 /**
  * Moodle core does not have a built-in functionality to get all keys of all children of a navigation node,
  * so we need to get these ourselves.
@@ -143,6 +149,36 @@ function local_boostnavigation_build_custom_nodes($customnodes, navigation_node 
                     switch ($i) {
                         // Check for the mandatory first param: title.
                         case 0:
+
+                            // check for line conditionals
+                            $ok = true;
+                            $hasconditional = false;
+                            if (substr($setting, 0, 3) === CONDITION_IS_LOGGED_IN) {
+                                $hasconditional = true;
+                                $ok = isloggedin();
+                            } else if (substr($setting, 0, 3) === CONTITION_NOT_LOGGED_IN) {
+                                $hasconditional = true;
+                                $ok = !isloggedin();
+                            } else if (substr($setting, 0, 3) === CONDITION_IS_GUEST) {
+                                $hasconditional = true;
+                                $ok = isguestuser();
+                            } else if (substr($setting, 0, 3) === CONTITION_IS_ADMIN) {
+                                $hasconditional = true;
+                                $ok = is_siteadmin();
+                            }
+                            // if a conditional was found ..
+                            if ($hasconditional) {
+                                // .. modify the remaining string by removing the conditional clause
+                                $setting = substr($setting, 3);
+
+                                // if conditional didn't pass ...
+                                if (!$ok) {
+                                    // .. this node isn't visible
+                                    $nodevisible = false;
+                                    break 2; // exit out of foreach
+                                }
+                            }
+
                             // Check if this is a child node and get the node title.
                             if (substr($setting, 0, 1) == '-') {
                                 $nodeischild = true;
@@ -728,6 +764,7 @@ function local_boostnavigation_customnodesusageusers() {
             get_string('setting_customnodesusageexamples', 'local_boostnavigation', null, true).'<br />'.
             '<code>'.get_string('setting_customnodesusageusersexample', 'local_boostnavigation', null, true).'</code><br />'.
             '<hr />'.
+            get_string('setting_conditionals', 'local_boostnavigation', null, true).'<br />'.
             get_string('setting_customnodesusageparameters', 'local_boostnavigation', null, true).'<br />'.
             '<dl>'.
             '<dt>'.get_string('setting_customnodesusageparametertitledt', 'local_boostnavigation', null, true).'</dt>'.
@@ -778,6 +815,7 @@ function local_boostnavigation_customnodesusageadmins() {
             get_string('setting_customnodesusageexamples', 'local_boostnavigation', null, true).'<br />'.
             '<code>'.get_string('setting_customnodesusageadminsexample', 'local_boostnavigation', null, true).'</code><br />'.
             '<hr />'.
+            get_string('setting_conditionals', 'local_boostnavigation', null, true).'<br />'.
             get_string('setting_customnodesusageparameters', 'local_boostnavigation', null, true).'<br />'.
             '<dl>'.
             '<dt>'.get_string('setting_customnodesusageparametertitledt', 'local_boostnavigation', null, true).'</dt>'.

--- a/locallib.php
+++ b/locallib.php
@@ -165,6 +165,12 @@ function local_boostnavigation_build_custom_nodes($customnodes, navigation_node 
                             } else if (substr($setting, 0, 3) === CONTITION_IS_ADMIN) {
                                 $hasconditional = true;
                                 $ok = is_siteadmin();
+                            } else if (preg_match('/^!(\d{1,10})!.+/', $setting, $regmatch)) {
+                                $setting = substr($setting, 2+ strlen($regmatch[1]));
+                                if ($USER->id != $regmatch[1]) {
+                                    $nodevisible = false;
+                                    break 2;
+                                }
                             }
                             // if a conditional was found ..
                             if ($hasconditional) {

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_boostnavigation';
-$plugin->version = 2020120902;
+$plugin->version = 2021080400;
 $plugin->release = 'v3.10-r3';
 $plugin->requires = 2020110900;
 $plugin->supported = [310, 310];


### PR DESCRIPTION
In relation to my question https://github.com/moodleuulm/moodle-local_boostnavigation/issues/95 here I present a novel approach to allowing any node to be conditionally shown to users who are logged on, not logged on or are guests.

I may not have done this a great way but I didn't want to have to specify all 10 array items for each line just to add a new condition on the end. Using a hard-coded prefix on the title seemed the easiest based on the logic within `local_boostnavigation_build_custom_nodes` and the character combination shouldn't clash most peoples needs.

Help string might need some work :)